### PR TITLE
Telugu characters in response and fixes

### DIFF
--- a/api/addCharacterAt.php
+++ b/api/addCharacterAt.php
@@ -42,7 +42,7 @@ function response($responseCode, $message, $string, $language, $data, $index, $c
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "index" => $index, "char" => $char, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 ?>

--- a/api/addCharacterAtEnd.php
+++ b/api/addCharacterAtEnd.php
@@ -40,7 +40,7 @@ function response($responseCode, $message, $string, $language, $data, $char)
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "char" => $char, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 ?>

--- a/api/getFillerCharacters.php
+++ b/api/getFillerCharacters.php
@@ -50,7 +50,7 @@ function response($responseCode, $message, $count, $type, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "count" => $count, "type" => $type, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/getLogicalChars.php
+++ b/api/getLogicalChars.php
@@ -40,7 +40,7 @@ function response($responseCode, $message, $string, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/logicalCharAt.php
+++ b/api/logicalCharAt.php
@@ -46,7 +46,7 @@ function response($responseCode, $message, $string, $index, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "index" => $index, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/parseToLogicalCharacters.php
+++ b/api/parseToLogicalCharacters.php
@@ -39,7 +39,7 @@ function response($responseCode, $message, $string, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/parseToLogicalChars.php
+++ b/api/parseToLogicalChars.php
@@ -39,7 +39,7 @@ function response($responseCode, $message, $string, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/replace.php
+++ b/api/replace.php
@@ -42,7 +42,7 @@ function response($responseCode, $message, $string, $language, $data, $target, $
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "target" => $target, "new" => $new, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 ?>

--- a/api/reverse.php
+++ b/api/reverse.php
@@ -39,7 +39,7 @@ function response($responseCode, $message, $string, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/api/splitWord.php
+++ b/api/splitWord.php
@@ -44,7 +44,7 @@ function response($responseCode, $message, $string, $col, $language, $data) {
 
     http_response_code($responseCode);
     $response = array("response_code" => $responseCode, "message" => $message, "string" => $string, "Columns" =>$col, "language" => $language, "data" => $data);
-    $json = json_encode($response);
+    $json = json_encode($response, JSON_UNESCAPED_UNICODE);
     echo $json;
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -182,8 +182,16 @@ async function callAPI(methodName) {
         const jsonObj = JSON.parse(newResult);
 
         jsonElement.innerHTML = result;
-        actualCell.innerHTML = jsonObj.data;
 
+        if(Array.isArray(jsonObj.data)) {
+            actualCell.innerHTML = jsonObj.data.toString();
+        }
+        else if(jsonObj.data?.constructor.name === "Object") {
+            actualCell.innerHTML = JSON.stringify(jsonObj.data);
+        }
+        else {
+            actualCell.innerHTML = jsonObj.data;
+        }
 
         if (jsonObj.response_code != 200) {
             passFail.innerHTML = "FAIL";
@@ -212,13 +220,12 @@ async function callAPI(methodName) {
  * Removes NON-ASCII characters from strings 
  */
 function remove_non_ascii(str) {
-
     if ((str === null) || (str === ''))
         return false;
     else
         str = str.toString();
 
-    return str.replace(/[^\x20-\x7E]/g, '');
+    return str.replace(/[^\x20-\x7E\uC00-\u0C7F]/g, '');
 }
 
 
@@ -320,7 +327,7 @@ function getDefaultValues(language) {
         document.getElementById("getUniqueIntersectingRankExpectedText").value = "5";
         document.getElementById("compareToExpectedText").value = "0";
         document.getElementById("compareToIgnoreCaseExpectedText").value = "2";
-        document.getElementById("splitWordExpectedText").value = "{'0': ['h', 'e'], '2': ['l', 'l'], '4': ['o', '']}";
+        document.getElementById("splitWordExpectedText").value = `{"0":["h","e"],"2":["l","l"],"4":["o",null]}`;
         document.getElementById("equalsExpectedText").value = "true";
         document.getElementById("reverseEqualsExpectedText").value = "true";
         document.getElementById("logicalCharAtExpectedText").value = "l";
@@ -394,7 +401,7 @@ function getDefaultValues(language) {
         document.getElementById("getUniqueIntersectingRankExpectedText").value = "8";
         document.getElementById("compareToExpectedText").value = "0";
         document.getElementById("compareToIgnoreCaseExpectedText").value = "-1";
-        document.getElementById("splitWordExpectedText").value = ""; //Need to update
+        document.getElementById("splitWordExpectedText").value = `{"0":["అ","మె"],"2":["రి","కా"],"4":["ఆ","స్ట్రే"],"6":["లి","యా"]}`;
         document.getElementById("equalsExpectedText").value = "true";
         document.getElementById("reverseEqualsExpectedText").value = "true";
         document.getElementById("logicalCharAtExpectedText").value = "లి";

--- a/js/parser.js
+++ b/js/parser.js
@@ -4,18 +4,8 @@ let language = "english";
 let table;
 
 function startup() {
-    registerParsingInput();
     registerSelectLanguage();
     table = $('#parsed-table').DataTable();
-    console.log('loaded');
-}
-
-function registerParsingInput() {
-    const parsing_input_area = document.querySelector('#parsing-input');
-
-    if(parsing_input_area) {
-        parsing_input_area.addEventListener('input', updateParseTable);
-    }
 }
 
 function registerSelectLanguage() {
@@ -85,7 +75,7 @@ async function getWordLengths() {
     const wordWithLength = new Map();
     
     for (const word of words) {
-        await fetch(`https://indic-wp.thisisjava.com/api/getLength.php?language=${language}&string=${word}`)
+        await fetch(`api/getLength.php?language=${language}&string=${word}`)
         .then(response => response.text())
         .then(data => result = data);
         
@@ -120,5 +110,5 @@ function remove_non_ascii(str) {
         return false;
     else
         str = str.toString();
-    return str.replace(/[^\x20-\x7E]/g, '');
+    return str.replace(/[^\x20-\x7E\uC00-\u0C7F]/g, '');
 }

--- a/parser.php
+++ b/parser.php
@@ -41,6 +41,9 @@
                 <div id="input-container" class="container my-5">
                     <textarea id="parsing-input" class="form-control" rows="10"></textarea>
                 </div>
+                <div id="buttons" class="container mb-4 d-flex justify-content-center">
+                    <button onclick="updateParseTable()" class="btn btn-outline-secondary w-25">Process</button>
+                </div>
                 <div id="table-container" class="container">
                     <table id="parsed-table">
                         <thead>


### PR DESCRIPTION
Adjusted it so that all APIs that have the potential to return Telugu, do so in their full form, versus unicode points.

Fixed split word bug and updated tests to properly fetch and display arrays and objects.

Changed the parser to only process the input when a button is pressed, versus automatically.